### PR TITLE
Add missing dependencies for BTC

### DIFF
--- a/docs/notary/setup-Komodo-Notary-Node.md
+++ b/docs/notary/setup-Komodo-Notary-Node.md
@@ -93,7 +93,7 @@ The instructions below are required on both of your servers.
 ### Install Required Dependencies
 
 ```bash
-sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev python-zmq zlib1g-dev wget curl bsdmainutils automake cmake clang libsodium-dev libcurl4-gnutls-dev libssl-dev git unzip python jq htop -y
+sudo apt-get install libboost-all-dev libevent-dev build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev python-zmq zlib1g-dev wget curl bsdmainutils automake cmake clang libsodium-dev libcurl4-gnutls-dev libssl-dev git unzip python jq htop -y
 ```
 
 ### Install `nanomsg`


### PR DESCRIPTION
Guide missing libboost-all-dev and libevent-dev in the dependencies list for MAin node build.