### PR TITLE
update BTC deps

### DIFF
--- a/docs/notary/setup-Komodo-Notary-Node.md
+++ b/docs/notary/setup-Komodo-Notary-Node.md
@@ -93,7 +93,7 @@ The instructions below are required on both of your servers.
 ### Install Required Dependencies
 
 ```bash
-sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev python-zmq zlib1g-dev wget curl bsdmainutils automake cmake clang libsodium-dev libcurl4-gnutls-dev libssl-dev git unzip python jq htop -y
+sudo apt-get install libevent-dev libboost-all-dev build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev python-zmq zlib1g-dev wget curl bsdmainutils automake cmake clang libsodium-dev libcurl4-gnutls-dev libssl-dev git unzip python jq htop -y
 ```
 
 ### Install `nanomsg`

--- a/docs/notary/setup-Komodo-Notary-Node.md
+++ b/docs/notary/setup-Komodo-Notary-Node.md
@@ -93,7 +93,7 @@ The instructions below are required on both of your servers.
 ### Install Required Dependencies
 
 ```bash
-sudo apt-get install libevent-dev libboost-all-dev build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev python-zmq zlib1g-dev wget curl bsdmainutils automake cmake clang libsodium-dev libcurl4-gnutls-dev libssl-dev git unzip python jq htop -y
+sudo apt-get install libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev python-zmq zlib1g-dev wget curl bsdmainutils automake cmake clang libsodium-dev libcurl4-gnutls-dev libssl-dev git unzip python jq htop -y
 ```
 
 ### Install `nanomsg`


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/Documentation/issues/48

Resolves `configure error: Could not link against boost_system`

And `configure: error: libevent not found.`  which I'm facing if use deps from list on clean Ubuntu 16.04/18.04 to build BTC

P.S. funny thing that official https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#ubuntu--debian instructions in Bitcoin repo missing some libboost dep it seems... maybe someone can find out which exactly part from libboost-all-dev (https://packages.ubuntu.com/bionic/libboost-all-dev) is missing and open PR there

UPD. oh just realised that since we using not latest 0.16 version some dep just needed at this time but not needed in new version so not presist in Bitcoin wiki