### PR TITLE
[setup-Komodo-NN] Fix `git clone` cmd for CHIPS

### DIFF
--- a/docs/notary/setup-Komodo-Notary-Node.md
+++ b/docs/notary/setup-Komodo-Notary-Node.md
@@ -563,7 +563,7 @@ chmod 600 ~/.aryacoin/aryacoin.conf
 
 ```bash
 cd ~
-git clone git clone https://github.com/chips-blockchain/chips -b master
+git clone https://github.com/chips-blockchain/chips -b master
 cd chips
 #git checkout 31d59f9
 ```


### PR DESCRIPTION
This PR fixes an incorrect `git clone` command for cloning the CHIPS repository.